### PR TITLE
Augment system type

### DIFF
--- a/lib/anthropix.ex
+++ b/lib/anthropix.ex
@@ -258,12 +258,15 @@ defmodule Anthropix do
   @doc """
   Calling `init/2` with an API key creates a new Anthropix API client, using the
   given API key. Optionally, a keyword list of options can be passed through to
-  `Req.new/1`.
+  `Req.new/1` or extra headers for Anthropic.
 
   ## Examples
 
   ```elixir
   iex> client = Anthropix.init("sk-ant-your-key", receive_timeout: :infinity)
+  %Anthropix{}
+
+  iex> client = Anthropix.init("sk-ant-your-key", headers: [{"anthropic-beta", "prompt-caching-2024-07-31"}])
   %Anthropix{}
   ```
   """


### PR DESCRIPTION
This allows system messages to be sent as a list of maps so multiple system messages can be sent and/or leverage prompt caching based on https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching.

Of course, for prompt caching to really works, a specific header and prompt caching directives need to be passed in but this PR at least will allow that to happen.

This is related to #5 