### PR TITLE
Fix Inconsistency in Tool Use Input Map Validation

### DIFF
--- a/lib/anthropix.ex
+++ b/lib/anthropix.ex
@@ -144,7 +144,7 @@ defmodule Anthropix do
     # tool_use
     id: [type: :string],
     name: [type: :string],
-    input: [type: :map],
+    input: [type: {:map, :string, :any}],
     # tool_result
     tool_use_id: [type: :string],
     is_error: [type: :boolean],


### PR DESCRIPTION
Update the NimbleOptions validation schema to accept string keys in the input map for tool_use messages. This change will align the validation with Claude's API response format, eliminating the need for key conversion and improving consistency.

Reference: #11 

```elixir
# Before
# tool_use
id: [type: :string],
name: [type: :string],
input: [type: :map],

# After
# tool_use
id: [type: :string],
name: [type: :string],
input: [type: {:map, :string, :any}],
```