### PR TITLE
Add status to APIError exception

### DIFF
--- a/lib/anthropix.ex
+++ b/lib/anthropix.ex
@@ -451,10 +451,8 @@ defmodule Anthropix do
     do: {:ok, response.body}
   defp res({:ok, %{status: status, body: body}}) when status in 200..299,
     do: {:ok, body}
-  defp res({:ok, %{body: ""}}),
-    do: {:error, "Empty response received"}
-  defp res({:ok, %{body: body}}),
-    do: {:error, APIError.exception(body)}
+  defp res({:ok, resp}),
+    do: {:error, APIError.exception(resp)}
   defp res({:error, error}), do: {:error, error}
 
 

--- a/lib/anthropix/api_error.ex
+++ b/lib/anthropix/api_error.ex
@@ -1,13 +1,20 @@
 defmodule Anthropix.APIError do
   @moduledoc false
-  defexception [:type, :message]
+  defexception [:status, :type, :message]
 
   @impl true
-  def exception(%{"error" => %{"type" => type, "message" => message}}) do
+  def exception(%{status: status, body: %{"error" => %{"type" => type, "message" => message}}}) do
     struct(__MODULE__, [
+      status: status,
       type: type,
       message: message,
-    ])
+      ])
+  end
+  def exception(%{status: status, body: ""}) do
+    struct(__MODULE__, [
+      status: status,
+      message: "Empty response received",
+      ])
   end
 
 end

--- a/lib/anthropix/batch.ex
+++ b/lib/anthropix/batch.ex
@@ -248,8 +248,8 @@ defmodule Anthropix.Batch do
     end
   end
 
-  defp res({:ok, %{body: body}}) do
-    {:error, APIError.exception(body)}
+  defp res({:ok, resp}) do
+    {:error, APIError.exception(resp)}
   end
 
   defp res({:error, error}), do: {:error, error}
@@ -276,8 +276,8 @@ defmodule Anthropix.Batch do
       {^ref, {:ok, %Req.Response{status: status}}} when status in 200..299 ->
         {:halt, task}
 
-      {^ref, {:ok, %Req.Response{body: body}}} ->
-        raise APIError.exception(body)
+      {^ref, {:ok, %Req.Response{}=resp}} ->
+        raise APIError.exception(resp)
 
       {^ref, {:error, error}} ->
         raise error

--- a/test/anthropix/batch_test.exs
+++ b/test/anthropix/batch_test.exs
@@ -56,7 +56,7 @@ defmodule Anthropix.BatchTest do
 
     test "returns 404 for unknown batch id" do
       client = Mock.client(& Mock.respond(&1, 404))
-      assert {:error, %APIError{type: "not_found"}} = Batch.show(client, "invalid_id")
+      assert {:error, %APIError{status: 404, type: "not_found"}} = Batch.show(client, "invalid_id")
     end
   end
 
@@ -98,7 +98,7 @@ defmodule Anthropix.BatchTest do
 
     test "returns 404 for unknown batch id" do
       client = Mock.client(& Mock.respond(&1, 404))
-      assert {:error, %APIError{type: "not_found"}} = Batch.results(client, "invalid_id")
+      assert {:error, %APIError{status: 404, type: "not_found"}} = Batch.results(client, "invalid_id")
     end
 
     test "with stream: true, returns a lazy enumerable" do

--- a/test/anthropix_test.exs
+++ b/test/anthropix_test.exs
@@ -155,7 +155,7 @@ defmodule AnthropixTest do
 
     test "returns error when model not found" do
       client = Mock.client(& Mock.respond(&1, 404))
-      assert {:error, %APIError{type: "not_found"}} = Anthropix.chat(client, [
+      assert {:error, %APIError{status: 404, type: "not_found"}} = Anthropix.chat(client, [
         model: "not-found",
         messages: [
           %{role: "user", content: "Write a haiku about the colour of the sky."}


### PR DESCRIPTION
This adds the status to the APIError exception. I need this for intelligent retry logic. 

If I exceed my call rate (429 status) I'll want to retry. Other errors I won't.